### PR TITLE
feat: Handle game over and reset with player actions synchronization

### DIFF
--- a/apps/client/src/components/GameBoard.tsx
+++ b/apps/client/src/components/GameBoard.tsx
@@ -3,15 +3,16 @@
 import { useEffect } from "react";
 import { useGameStore } from "@client/store/game";
 import { useSocket } from "@client/hooks/useSocket";
+import { Button } from "@tic-tac-toe/ui";
 
 const GameBoard = () => {
-  const { board, roomId } = useGameStore((state) => state);
+  const { board, roomId, gameOverMessage } = useGameStore((state) => state);
   const updateGameState = useGameStore((state) => state.setGameState);
+  const setGameOverMessage = useGameStore((state) => state.setGameOverState);
   const socket = useSocket();
 
   const handleCellClick = (row: number, col: number) => {
-    console.log("Clicked cell:", row, col, "Room ID:", roomId); // debug
-    if (!roomId) return;
+    if (!roomId || gameOverMessage) return;
     socket.emit("make_move", { roomId, row, col });
   };
 
@@ -20,26 +21,137 @@ const GameBoard = () => {
       updateGameState(newState);
     });
 
+    socket.on("game_over", (data) => {
+      if (data.draw) {
+        setGameOverMessage("It's a draw!");
+      } else {
+        setGameOverMessage(`Player ${data.winner} wins!`);
+      }
+    });
+
     return () => {
       socket.off("game_update");
+      socket.off("game_over");
     };
-  }, [socket, updateGameState]);
+  }, [socket, updateGameState, setGameOverMessage]);
 
   return (
-    <div className="grid grid-cols-3 gap-2 max-w-md mx-auto mt-8">
-      {board.map((row, rowIndex) =>
-        row.map((cell, colIndex) => (
-          <div
-            key={`${rowIndex}-${colIndex}`}
-            className="aspect-square border border-gray-400 flex items-center justify-center text-2xl cursor-pointer"
-            onClick={() => handleCellClick(rowIndex, colIndex)}
-          >
-            {cell}
+    <div className="max-w-md mx-auto mt-8">
+      {gameOverMessage && (
+        <>
+          <div className="bg-yellow-100 border border-yellow-400 text-yellow-800 px-4 py-2 rounded mb-4 text-center">
+            {gameOverMessage}
           </div>
-        ))
+          <div className="flex justify-center mb-4">
+            <Button
+              onClick={() => {
+                if (roomId) {
+                  socket.emit("play_again", { roomId });
+                  setGameOverMessage(null);
+                }
+              }}
+            >
+              Play Again
+            </Button>
+          </div>
+        </>
       )}
+
+      <div className="grid grid-cols-3 gap-2">
+        {board.map((row, rowIndex) =>
+          row.map((cell, colIndex) => (
+            <div
+              key={`${rowIndex}-${colIndex}`}
+              className="aspect-square border border-gray-400 flex items-center justify-center text-2xl cursor-pointer"
+              onClick={() => handleCellClick(rowIndex, colIndex)}
+            >
+              {cell}
+            </div>
+          ))
+        )}
+      </div>
     </div>
   );
 };
 
 export default GameBoard;
+
+// "use client";
+
+// import { useEffect } from "react";
+// import { useGameStore } from "@client/store/game";
+// import { useSocket } from "@client/hooks/useSocket";
+// import { Button } from "@tic-tac-toe/ui";
+
+// const GameBoard = () => {
+//   const { board, roomId, gameOverMessage } = useGameStore((state) => state);
+//   const updateGameState = useGameStore((state) => state.setGameState);
+//   const setGameOverMessage = useGameStore((state) => state.setGameOverState);
+//   const socket = useSocket();
+
+//   const handleCellClick = (row: number, col: number) => {
+//     console.log("Clicked cell:", row, col, "Room ID:", roomId); // debug
+//     if (!roomId || gameOverMessage) return;
+//     socket.emit("make_move", { roomId, row, col });
+//   };
+
+//   useEffect(() => {
+//     socket.on("game_update", (newState) => {
+//       updateGameState(newState);
+//     });
+
+//     socket.on("game_over", (data) => {
+//       if (data.draw) {
+//         setGameOverMessage("It's a draw!");
+//       } else {
+//         setGameOverMessage(`Player ${data.winner} wins!`);
+//       }
+//       console.log("Game Over:", data);
+//     });
+
+//     return () => {
+//       socket.off("game_update");
+//     };
+//   }, [socket, updateGameState, setGameOverMessage]);
+
+//   return (
+//     <div className="max-w-md mx-auto mt-8">
+//       {gameOverMessage && (
+//         <>
+//           <div
+//             className="bg-yellow-100 border border-yellow-400 text-yellow-800
+//         px-4 py-2 rounded mb-4 text-center"
+//           >
+//             {gameOverMessage}
+//           </div>
+
+//           <div className="flex justify-center mb-4">
+//             <Button
+//               onClick={() => {
+//                 socket.emit("play_again", { roomId });
+//               }}
+//             >
+//               Play Again
+//             </Button>
+//           </div>
+//         </>
+//       )}
+
+//       <div className="grid grid-cols-3 gap-2">
+//         {board.map((row, rowIndex) =>
+//           row.map((cell, colIndex) => (
+//             <div
+//               key={`${rowIndex}-${colIndex}`}
+//               className="aspect-square border border-gray-400 flex items-center justify-center text-2xl cursor-pointer"
+//               onClick={() => handleCellClick(rowIndex, colIndex)}
+//             >
+//               {cell}
+//             </div>
+//           ))
+//         )}
+//       </div>
+//     </div>
+//   );
+// };
+
+// export default GameBoard;

--- a/apps/client/src/store/game.ts
+++ b/apps/client/src/store/game.ts
@@ -4,10 +4,14 @@ type GameState = {
   roomId: string;
   board: string[][];
   currentPlayer: string;
+  gameOverMessage: string | null;
 };
 
 type GameStore = GameState & {
   setGameState: (state: GameState) => void;
+  gameOverMessage: string | null;
+  setGameOverState: (message: string | null) => void;
+  resetGame: () => void;
 };
 
 export const useGameStore = create<GameStore>((set) => ({
@@ -18,5 +22,17 @@ export const useGameStore = create<GameStore>((set) => ({
     ["", "", ""],
   ],
   currentPlayer: "",
+  gameOverMessage: null,
   setGameState: (state) => set(() => ({ ...state })),
+  setGameOverState: (message) => set(() => ({ gameOverMessage: message })),
+  resetGame: () =>
+    set(() => ({
+      board: [
+        ["", "", ""],
+        ["", "", ""],
+        ["", "", ""],
+      ],
+      currentPlayer: "",
+      gameOverMessage: null,
+    })),
 }));

--- a/apps/server/src/gameManager.ts
+++ b/apps/server/src/gameManager.ts
@@ -11,7 +11,7 @@ type RoomId = string;
 export interface GameState {
   board: Board;
   currentPlayer: Player;
-  players: string[]; // The socket IDs
+  players: string[]; // socket IDs
   winner: Player | "draw" | null;
 }
 
@@ -32,7 +32,6 @@ export function joinRoom(roomId: string, socketId: string): GameState | null {
   const room = rooms.get(roomId);
   if (!room || room.players.length >= 2) return null;
   room.players.push(socketId);
-
   return room;
 }
 
@@ -43,49 +42,133 @@ export function makePlayerMove(
   col: number
 ): GameState | null {
   const game = rooms.get(roomId);
-
   if (!game || game.winner || game.players.length < 2) return null;
 
   const playerIndex = game.players.indexOf(socketId);
-  const playerSymbol = playerIndex === 0 ? "X" : "O";
+  if (playerIndex === -1) return null;
 
+  const playerSymbol: Player = playerIndex === 0 ? "X" : "O";
   if (playerSymbol !== game.currentPlayer) return null;
 
-  // Log the current game state before the move - For Debugging
-  console.log("Current Game State:", game);
-  console.log("Player Symbol:", playerSymbol);
-  console.log("Making move at position:", row, col);
-
   const newBoard = makeMove(game.board, row, col, playerSymbol);
-
-  // Log the new board after the move - For Debugging
-  console.log("New Board after move:", newBoard);
-
-  if (newBoard === game.board) return null; // Move is invalid
+  if (newBoard === game.board) return null;
 
   game.board = newBoard;
   game.winner = checkWinner(newBoard);
 
-  // Log the winner after the move - For Debugging
-  console.log("Winner after move:", game.winner);
-
-  // Check for a draw
   if (
     !game.winner &&
     game.board.every((row) => row.every((cell) => cell !== null))
   ) {
     game.winner = "draw";
-    console.log("Game is a draw!");
   }
 
   if (!game.winner) {
     game.currentPlayer = game.currentPlayer === "X" ? "O" : "X";
-    console.log("Next player:", game.currentPlayer);
   }
 
   return game;
 }
 
-export function getGameState(roomId: string): GameState | null {
-  return rooms.get(roomId) || null;
+export function resetGame(roomId: string): GameState | null {
+  const game = rooms.get(roomId);
+  if (!game) return null;
+
+  game.board = createEmptyBoard();
+  game.currentPlayer = "X";
+  game.winner = null;
+
+  return game;
 }
+
+// import {
+//   createEmptyBoard,
+//   Player,
+//   Board,
+//   makeMove,
+//   checkWinner,
+// } from "shared/src/tictactoe";
+
+// type RoomId = string;
+
+// export interface GameState {
+//   board: Board;
+//   currentPlayer: Player;
+//   players: string[]; // The socket IDs
+//   winner: Player | "draw" | null;
+// }
+
+// const rooms = new Map<RoomId, GameState>();
+
+// export function createRoom(roomId: string, socketId: string): GameState {
+//   const state: GameState = {
+//     board: createEmptyBoard(),
+//     currentPlayer: "X",
+//     players: [socketId],
+//     winner: null,
+//   };
+//   rooms.set(roomId, state);
+//   return state;
+// }
+
+// export function joinRoom(roomId: string, socketId: string): GameState | null {
+//   const room = rooms.get(roomId);
+//   if (!room || room.players.length >= 2) return null;
+//   room.players.push(socketId);
+
+//   return room;
+// }
+
+// export function makePlayerMove(
+//   roomId: string,
+//   socketId: string,
+//   row: number,
+//   col: number
+// ): GameState | null {
+//   const game = rooms.get(roomId);
+
+//   if (!game || game.winner || game.players.length < 2) return null;
+
+//   const playerIndex = game.players.indexOf(socketId);
+//   const playerSymbol = playerIndex === 0 ? "X" : "O";
+
+//   if (playerSymbol !== game.currentPlayer) return null;
+
+//   // Log the current game state before the move - For Debugging
+//   console.log("Current Game State:", game);
+//   console.log("Player Symbol:", playerSymbol);
+//   console.log("Making move at position:", row, col);
+
+//   const newBoard = makeMove(game.board, row, col, playerSymbol);
+
+//   // Log the new board after the move - For Debugging
+//   console.log("New Board after move:", newBoard);
+
+//   if (newBoard === game.board) return null; // Move is invalid
+
+//   game.board = newBoard;
+//   game.winner = checkWinner(newBoard);
+
+//   // Log the winner after the move - For Debugging
+//   console.log("Winner after move:", game.winner);
+
+//   // Check for a draw
+//   if (
+//     !game.winner &&
+//     game.board.every((row) => row.every((cell) => cell !== null))
+//   ) {
+//     game.winner = "draw";
+//     console.log("Game is a draw!");
+//   }
+
+//   if (!game.winner) {
+//     game.currentPlayer = game.currentPlayer === "X" ? "O" : "X";
+//     console.log("Next player:", game.currentPlayer);
+//   }
+
+//   return game;
+// }
+
+// export function getGameState(roomId: string): GameState | null {
+//   return rooms.get(roomId) || null;
+// }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -3,7 +3,13 @@ import express, { Request, Response } from "express";
 import http from "http";
 import { Server } from "socket.io";
 
-import { createRoom, joinRoom, makePlayerMove } from "./gameManager";
+import {
+  createRoom,
+  joinRoom,
+  makePlayerMove,
+  GameState,
+  resetGame,
+} from "./gameManager";
 
 const app = express();
 const server = http.createServer(app);
@@ -21,70 +27,96 @@ app.get("/", (_: Request, res: Response) => {
   res.send("Tic Tac Toe Realtime Server is up 🚀");
 });
 
-const rooms = new Map<string, Set<string>>(); // Store socket IDs for room players
+const rooms = new Map<string, GameState>();
 
 io.on("connection", (socket) => {
   console.log(`⚡️ New client connected: ${socket.id}`);
 
   socket.on("create_room", (roomId) => {
-    console.log(`📦 Creating room ${roomId} by ${socket.id}`); // Log for debugging
-
     const game = createRoom(roomId, socket.id);
-    rooms.set(roomId, new Set([socket.id])); // Store the socket ID in the room
+    rooms.set(roomId, game);
 
     socket.join(roomId);
     socket.emit("room_joined", game);
 
-    // Log the room ID after it's created for testing purposes
-    console.log(`Room created with ID: ${roomId}`);
+    console.log(`📦 Room created with ID: ${roomId}`);
+    console.log(`🎮 Player ${socket.id} created and joined room ${roomId}`);
   });
 
   socket.on("join_room", (roomId) => {
     const game = joinRoom(roomId, socket.id);
 
     if (game) {
-      rooms.get(roomId)?.add(socket.id); // Add the new player to the room
+      rooms.set(roomId, game);
       socket.join(roomId);
       io.to(roomId).emit("room_joined", game);
-
-      console.log(`Player ${socket.id} joined room ${roomId}`); // Log for debugging
+      console.log(`🎮 Player ${socket.id} joined room ${roomId}`);
     } else {
       socket.emit("error", "Oops, Room is full or doesn't exist");
     }
-
-    console.log(
-      `All clients in room ${roomId}:`,
-      Array.from(io.sockets.adapter.rooms.get(roomId) || [])
-    );
   });
 
   socket.on("make_move", ({ roomId, row, col }) => {
-    console.log(`Player ${socket.id} is making a move at (${row}, ${col})`);
+    // Log the move attempt
+    console.log(
+      `🟢 Player ${socket.id} is attempting a move in room ${roomId}: (${row}, ${col})`
+    );
 
     const game = makePlayerMove(roomId, socket.id, row, col);
 
     if (game) {
-      console.log("Game updated:", game);
+      // Log the updated board and current player
+      console.log(
+        `🧩 Updated board in room ${roomId} after player ${socket.id}'s move:`
+      );
+      console.log(game.board.slice(0, 3).join(" | "));
+      console.log(game.board.slice(3, 6).join(" | "));
+      console.log(game.board.slice(6, 9).join(" | "));
+      console.log(`🎮 Next turn: Player ${game.currentPlayer}`);
+
       io.to(roomId).emit("game_update", game);
+
+      if (game.winner) {
+        // Log the winner or if the game ended in a draw
+        if (game.winner === "draw") {
+          console.log(`🤝🏽 The game in room ${roomId} ended in a draw.`);
+        } else {
+          console.log(
+            `🏆 The winner of the game in room ${roomId} is Player ${game.winner}!`
+          );
+        }
+
+        io.to(roomId).emit("game_over", {
+          winner: game.winner === "draw" ? null : game.winner,
+          draw: game.winner === "draw",
+        });
+      }
     } else {
-      console.log(`Move failed for player ${socket.id}. Invalid move!`);
-      socket.emit("error", "Uh oh, you just tried to make an invalid move!");
+      // Log if the move was invalid
+      console.log(`🚫 Invalid move by player ${socket.id} in room ${roomId}`);
+
+      socket.emit("error", "Invalid move!");
+    }
+  });
+
+  socket.on("play_again", ({ roomId }) => {
+    const updatedGame = resetGame(roomId);
+    if (updatedGame) {
+      io.to(roomId).emit("game_update", updatedGame);
     }
   });
 
   socket.on("disconnect", () => {
     console.log(`❌ Client disconnected: ${socket.id}`);
 
-    for (const [roomId, players] of rooms.entries()) {
-      if (players.has(socket.id)) {
-        players.delete(socket.id); // Remove the player from the room
+    for (const [roomId, game] of rooms.entries()) {
+      if (game.players.includes(socket.id)) {
+        game.players = game.players.filter((id) => id !== socket.id);
 
-        if (players.size === 0) {
-          // If no players left, remove the room
+        if (game.players.length === 0) {
           rooms.delete(roomId);
-          console.log(`Room ${roomId} is now empty and deleted`); // Log for debugging
+          console.log(`🗑 Room ${roomId} deleted`);
         } else {
-          // Notify other players in the room that someone disconnected
           io.to(roomId).emit("player_disconnected", {
             message: `Player ${socket.id} disconnected.`,
           });
@@ -98,3 +130,113 @@ io.on("connection", (socket) => {
 server.listen(PORT, () => {
   console.log(`✅ Server running on port: ${PORT}`);
 });
+
+// import cors from "cors";
+// import express, { Request, Response } from "express";
+// import http from "http";
+// import { Server } from "socket.io";
+
+// import { createRoom, joinRoom, makePlayerMove } from "./gameManager";
+// import { checkWinner } from "shared";
+
+// const app = express();
+// const server = http.createServer(app);
+// const io = new Server(server, {
+//   cors: {
+//     origin: "*", // TODO: Adjust this in production
+//     methods: ["GET", "POST"],
+//   },
+// });
+
+// const PORT = process.env.PORT || 4001;
+
+// app.use(cors());
+// app.get("/", (_: Request, res: Response) => {
+//   res.send("Tic Tac Toe Realtime Server is up 🚀");
+// });
+
+// const rooms = new Map<string, Set<string>>(); // Store socket IDs for room players
+
+// io.on("connection", (socket) => {
+//   console.log(`⚡️ New client connected: ${socket.id}`);
+
+//   socket.on("create_room", (roomId) => {
+//     console.log(`📦 Creating room ${roomId} by ${socket.id}`); // Log for debugging
+
+//     const game = createRoom(roomId, socket.id);
+//     rooms.set(roomId, new Set([socket.id])); // Store the socket ID in the room
+
+//     socket.join(roomId);
+//     socket.emit("room_joined", game);
+
+//     // Log the room ID after it's created for testing purposes
+//     console.log(`Room created with ID: ${roomId}`);
+//   });
+
+//   socket.on("join_room", (roomId) => {
+//     const game = joinRoom(roomId, socket.id);
+
+//     if (game) {
+//       rooms.get(roomId)?.add(socket.id); // Add the new player to the room
+//       socket.join(roomId);
+//       io.to(roomId).emit("room_joined", game);
+
+//       console.log(`Player ${socket.id} joined room ${roomId}`); // Log for debugging
+//     } else {
+//       socket.emit("error", "Oops, Room is full or doesn't exist");
+//     }
+
+//     console.log(
+//       `All clients in room ${roomId}:`,
+//       Array.from(io.sockets.adapter.rooms.get(roomId) || [])
+//     );
+//   });
+
+//   socket.on("make_move", ({ roomId, row, col }) => {
+//     console.log(`Player ${socket.id} is making a move at (${row}, ${col})`);
+
+//     const game = makePlayerMove(roomId, socket.id, row, col);
+
+//     if (game) {
+//       console.log("Game updated:", game);
+
+//       io.to(roomId).emit("game_update", game);
+
+//       if (game.winner) {
+//         io.to(roomId).emit("game_over", {
+//           winner: game.winner === "draw" ? null : game.winner,
+//           draw: game.winner === "draw",
+//         });
+//       }
+//     } else {
+//       console.log(`Move failed for player ${socket.id}. Invalid move!`);
+//       socket.emit("error", "Uh oh, you just tried to make an invalid move!");
+//     }
+//   });
+
+//   socket.on("disconnect", () => {
+//     console.log(`❌ Client disconnected: ${socket.id}`);
+
+//     for (const [roomId, players] of rooms.entries()) {
+//       if (players.has(socket.id)) {
+//         players.delete(socket.id); // Remove the player from the room
+
+//         if (players.size === 0) {
+//           // If no players left, remove the room
+//           rooms.delete(roomId);
+//           console.log(`Room ${roomId} is now empty and deleted`); // Log for debugging
+//         } else {
+//           // Notify other players in the room that someone disconnected
+//           io.to(roomId).emit("player_disconnected", {
+//             message: `Player ${socket.id} disconnected.`,
+//           });
+//         }
+//         break;
+//       }
+//     }
+//   });
+// });
+
+// server.listen(PORT, () => {
+//   console.log(`✅ Server running on port: ${PORT}`);
+// });


### PR DESCRIPTION
- Implemented synchronization of game **reset** for both players.
- Fixed **issue** after reset game so the players can play again.
- Updated `make move` **socket** and **make player move** logic.
- Emitted `game update` and checking for **winner/draw** detection.
- Emitted `game over` event.
- Received and displayed winner/draw on client side.
- ### Added play again button:
   - Firstly, emitted a `play again` **event** to the server.
   - Secondly, reset the game **state** on both the server and the client.
- Improved handling of game state after `play again` is **triggered**.