### PR TITLE
feat(homepage-gamemode): Add homepage

### DIFF
--- a/apps/client/src/app/page.tsx
+++ b/apps/client/src/app/page.tsx
@@ -1,27 +1,103 @@
 "use client";
 
 import { useState } from "react";
+import { useGameStore } from "@client/store/game";
 import RoomForm from "@client/components/RoomForm";
 import GameBoard from "@client/components/GameBoard";
 import { PlayerSetupModal } from "@client/components/modals/PlayerSetupModal";
 
 export default function HomePage() {
+  const { gameFlow, setGameState } = useGameStore();
   const [showModal, setShowModal] = useState(true);
 
-  return (
-    // <main className="min-h-screen p-4 flex flex-col items-center justify-start">
-    <main className="min-h-screen p-4">
-      <h1 className="text-4xl font-bold mt-8 flex justify-center">
-        Tic Tac Toe
-      </h1>
-      {showModal ? (
-        <PlayerSetupModal onConfirm={() => setShowModal(false)} />
-      ) : (
-        <>
-          <RoomForm />
+  const handlePlayerVsPlayer = () => {
+    setGameState({ gameFlow: "SELECT_MODE" });
+  };
+
+  const handleHelp = () => {
+    alert("This will show a help guide soon! 🚀");
+  };
+
+  if (gameFlow === "HOME") {
+    return (
+      <main className="min-h-screen p-4 flex flex-col items-center justify-center space-y-4">
+        <h1 className="text-4xl font-bold mb-8">Welcome to Tic Tac Toe 🎲</h1>
+        <button
+          className="px-6 py-3 bg-blue-500 text-white rounded hover:bg-blue-600"
+          onClick={handlePlayerVsPlayer}
+        >
+          Play Against Player
+        </button>
+        <button
+          className="px-6 py-3 bg-gray-400 text-white rounded cursor-not-allowed"
+          disabled
+        >
+          Play Against CPU (Coming Soon)
+        </button>
+        <button
+          className="px-6 py-3 bg-gray-400 text-white rounded cursor-not-allowed"
+          disabled
+        >
+          View Available Rooms (Coming Soon)
+        </button>
+        <button
+          className="px-6 py-3 bg-green-500 text-white rounded hover:bg-green-600"
+          onClick={handleHelp}
+        >
+          Help Guide
+        </button>
+      </main>
+    );
+  }
+
+  if (gameFlow === "SELECT_MODE") {
+    return (
+      <main className="min-h-screen p-4 flex flex-col items-center justify-start">
+        <RoomForm />
+      </main>
+    );
+  }
+
+  if (gameFlow === "SETUP_ROOM") {
+    return (
+      <>
+        {showModal && (
+          <PlayerSetupModal onConfirm={() => setShowModal(false)} />
+        )}
+        <main className="min-h-screen p-4 flex flex-col items-center justify-start">
           <GameBoard />
-        </>
-      )}
-    </main>
-  );
+        </main>
+      </>
+    );
+  }
+
+  return null;
 }
+
+// "use client";
+
+// import { useState } from "react";
+// import RoomForm from "@client/components/RoomForm";
+// import GameBoard from "@client/components/GameBoard";
+// import { PlayerSetupModal } from "@client/components/modals/PlayerSetupModal";
+
+// export default function HomePage() {
+//   const [showModal, setShowModal] = useState(true);
+
+//   return (
+//     // <main className="min-h-screen p-4 flex flex-col items-center justify-start">
+//     <main className="min-h-screen p-4">
+//       <h1 className="text-4xl font-bold mt-8 flex justify-center">
+//         Tic Tac Toe
+//       </h1>
+//       {showModal ? (
+//         <PlayerSetupModal onConfirm={() => setShowModal(false)} />
+//       ) : (
+//         <>
+//           <RoomForm />
+//           <GameBoard />
+//         </>
+//       )}
+//     </main>
+//   );
+// }

--- a/apps/client/src/components/RoomForm.tsx
+++ b/apps/client/src/components/RoomForm.tsx
@@ -1,65 +1,80 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSocket } from "@client/hooks/useSocket";
 import { useGameStore } from "@client/store/game";
 import { Button } from "@tic-tac-toe/ui";
+
+type PlayersInfo = {
+  players: { id: string; name: string; symbol: "X" | "O" }[];
+  currentPlayerId: string;
+};
 
 const RoomForm = () => {
   const [roomId, setRoomId] = useState("");
   const [playerName, setPlayerName] = useState("");
   const [symbol, setSymbol] = useState<"X" | "O">("X");
+
   const socket = useSocket();
   const setGameState = useGameStore((state) => state.setGameState);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handlePlayersInfo = (data: PlayersInfo) => {
+      setGameState({ ...data, roomId });
+    };
+
+    const handleError = (err: string) => {
+      alert(err);
+    };
+
+    socket.on("players_info", handlePlayersInfo);
+    socket.on("error", handleError);
+
+    // Cleanup: remove listeners when unmounting
+    return () => {
+      socket.off("players_info", handlePlayersInfo);
+      socket.off("error", handleError);
+    };
+  }, [socket, setGameState, roomId]);
 
   const handleCreateOrJoinRoom = (type: "create" | "join") => {
     if (!roomId.trim() || !playerName.trim()) return;
 
     if (type === "create") {
-      socket.emit("create_room", {
-        roomId,
-        playerName,
-        symbol,
-      });
+      socket.emit("create_room", { roomId, playerName, symbol });
     } else {
-      socket.emit("join_room", {
-        roomId,
-        playerName,
-      });
+      socket.emit("join_room", { roomId, playerName });
     }
 
-    socket.on("players_info", (data) => {
-      setGameState({ ...data, roomId });
-    });
-
-    socket.on("error", (err) => {
-      alert(err);
-    });
+    // Immediately update game state to show the 'setting up' status
+    setGameState({ gameFlow: "SETUP_ROOM" });
   };
 
   return (
     <div className="flex flex-col items-center gap-4 mt-10">
       <input
+        className="border px-4 py-2 rounded w-64"
         type="text"
         value={playerName}
-        onChange={(e) => setPlayerName(e.target.value)}
-        placeholder="Enter your name"
-        className="border px-4 py-2 rounded w-64"
+        onChange={(evt) => setPlayerName(evt.target.value)}
+        placeholder="Please Enter Your Name"
       />
       <input
+        className="border px-4 py-2 rounded w-64"
         type="text"
         value={roomId}
-        onChange={(e) => setRoomId(e.target.value)}
+        onChange={(evt) => setRoomId(evt.target.value)}
         placeholder="Enter room ID"
-        className="border px-4 py-2 rounded w-64"
       />
 
       <div className="flex items-center gap-4">
         <label className="text-sm font-medium">Symbol:</label>
         <select
-          value={symbol}
-          onChange={(e) => setSymbol(e.target.value as "X" | "O")}
           className="px-4 py-2 rounded border"
+          value={symbol}
+          onChange={(evt) => setSymbol(evt.target.value as "X" | "O")}
         >
           <option value="X">X</option>
           <option value="O">O</option>
@@ -68,14 +83,14 @@ const RoomForm = () => {
 
       <div className="flex space-x-2 mt-4">
         <Button
-          onClick={() => handleCreateOrJoinRoom("create")}
           className="bg-green-500 text-white px-4 py-2 rounded"
+          onClick={() => handleCreateOrJoinRoom("create")}
         >
           Create Room
         </Button>
         <Button
-          onClick={() => handleCreateOrJoinRoom("join")}
           className="bg-blue-500 text-white px-4 py-2 rounded"
+          onClick={() => handleCreateOrJoinRoom("join")}
         >
           Join Room
         </Button>
@@ -85,3 +100,93 @@ const RoomForm = () => {
 };
 
 export default RoomForm;
+
+// "use client";
+
+// import { useState } from "react";
+// import { useSocket } from "@client/hooks/useSocket";
+// import { useGameStore } from "@client/store/game";
+// import { Button } from "@tic-tac-toe/ui";
+
+// const RoomForm = () => {
+//   const [roomId, setRoomId] = useState("");
+//   const [playerName, setPlayerName] = useState("");
+//   const [symbol, setSymbol] = useState<"X" | "O">("X");
+//   const socket = useSocket();
+//   const setGameState = useGameStore((state) => state.setGameState);
+
+//   const handleCreateOrJoinRoom = (type: "create" | "join") => {
+//     if (!roomId.trim() || !playerName.trim()) return;
+
+//     if (type === "create") {
+//       socket.emit("create_room", {
+//         roomId,
+//         playerName,
+//         symbol,
+//       });
+//     } else {
+//       socket.emit("join_room", {
+//         roomId,
+//         playerName,
+//       });
+//     }
+
+//     setGameState({ gameFlow: "SETUP_ROOM" });
+
+//     socket.on("players_info", (data) => {
+//       setGameState({ ...data, roomId });
+//     });
+
+//     socket.on("error", (err) => {
+//       alert(err);
+//     });
+//   };
+
+//   return (
+//     <div className="flex flex-col items-center gap-4 mt-10">
+//       <input
+//         type="text"
+//         value={playerName}
+//         onChange={(e) => setPlayerName(e.target.value)}
+//         placeholder="Enter your name"
+//         className="border px-4 py-2 rounded w-64"
+//       />
+//       <input
+//         type="text"
+//         value={roomId}
+//         onChange={(e) => setRoomId(e.target.value)}
+//         placeholder="Enter room ID"
+//         className="border px-4 py-2 rounded w-64"
+//       />
+
+//       <div className="flex items-center gap-4">
+//         <label className="text-sm font-medium">Symbol:</label>
+//         <select
+//           value={symbol}
+//           onChange={(e) => setSymbol(e.target.value as "X" | "O")}
+//           className="px-4 py-2 rounded border"
+//         >
+//           <option value="X">X</option>
+//           <option value="O">O</option>
+//         </select>
+//       </div>
+
+//       <div className="flex space-x-2 mt-4">
+//         <Button
+//           onClick={() => handleCreateOrJoinRoom("create")}
+//           className="bg-green-500 text-white px-4 py-2 rounded"
+//         >
+//           Create Room
+//         </Button>
+//         <Button
+//           onClick={() => handleCreateOrJoinRoom("join")}
+//           className="bg-blue-500 text-white px-4 py-2 rounded"
+//         >
+//           Join Room
+//         </Button>
+//       </div>
+//     </div>
+//   );
+// };
+
+// export default RoomForm;

--- a/apps/client/src/store/game.ts
+++ b/apps/client/src/store/game.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
 
+type GameFlow = "HOME" | "SELECT_MODE" | "SETUP_ROOM" | "IN_GAME";
+
 type GameState = {
   roomId: string;
   board: string[][];
@@ -9,11 +11,11 @@ type GameState = {
   opponentName: string;
   playerSymbol: "X" | "O" | "";
   opponentSymbol: "X" | "O" | "";
+  gameFlow: GameFlow;
 };
 
 type GameStore = GameState & {
   setGameState: (state: Partial<GameState>) => void;
-  // gameOverMessage: string | null;
   setGameOverState: (message: string | null) => void;
   resetGame: () => void;
 };
@@ -31,6 +33,7 @@ export const useGameStore = create<GameStore>((set) => ({
   opponentName: "",
   playerSymbol: "",
   opponentSymbol: "",
+  gameFlow: "HOME",
   setGameState: (state) => set((prev) => ({ ...prev, ...state })),
   setGameOverState: (message) => set(() => ({ gameOverMessage: message })),
   resetGame: () =>
@@ -47,5 +50,58 @@ export const useGameStore = create<GameStore>((set) => ({
       opponentName: state.opponentName,
       playerSymbol: state.playerSymbol,
       opponentSymbol: state.opponentSymbol,
+      gameFlow: "HOME",
     })),
 }));
+
+// import { create } from "zustand";
+
+// type GameState = {
+//   roomId: string;
+//   board: string[][];
+//   currentPlayer: string;
+//   gameOverMessage: string | null;
+//   playerName: string;
+//   opponentName: string;
+//   playerSymbol: "X" | "O" | "";
+//   opponentSymbol: "X" | "O" | "";
+// };
+
+// type GameStore = GameState & {
+//   setGameState: (state: Partial<GameState>) => void;
+//   // gameOverMessage: string | null;
+//   setGameOverState: (message: string | null) => void;
+//   resetGame: () => void;
+// };
+
+// export const useGameStore = create<GameStore>((set) => ({
+//   roomId: "",
+//   board: [
+//     ["", "", ""],
+//     ["", "", ""],
+//     ["", "", ""],
+//   ],
+//   currentPlayer: "",
+//   gameOverMessage: null,
+//   playerName: "",
+//   opponentName: "",
+//   playerSymbol: "",
+//   opponentSymbol: "",
+//   setGameState: (state) => set((prev) => ({ ...prev, ...state })),
+//   setGameOverState: (message) => set(() => ({ gameOverMessage: message })),
+//   resetGame: () =>
+//     set((state) => ({
+//       board: [
+//         ["", "", ""],
+//         ["", "", ""],
+//         ["", "", ""],
+//       ],
+//       currentPlayer: "",
+//       gameOverMessage: null,
+//       roomId: state.roomId,
+//       playerName: state.playerName,
+//       opponentName: state.opponentName,
+//       playerSymbol: state.playerSymbol,
+//       opponentSymbol: state.opponentSymbol,
+//     })),
+// }));


### PR DESCRIPTION
- ### Added homepage with options:
   - Play vs Player
   - Play vs CPU (For now inactive, coming later on)
   - View Available Rooms (For now inactive, coming later on)
   - Help Guide (Coming later on)

- Show **`RoomForm`** only after selecting Play vs Player.

- Integrated game flow tracking in **`useGameState`** to control steps.

- Updated `page.tsx` to reflect new homepage-first flow.

- Using minimal UI for now, will enhance with design system and Storybook later on.